### PR TITLE
Toggle audio.pause() and audio.play()

### DIFF
--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -22,7 +22,7 @@ const Episode = ({
   const togglePlay = () => {
     setIsPlaying(!isPlaying)
     let audio = document.getElementById("audio-player")
-    isPlaying ? audio.play() : audio.pause()
+    isPlaying ? audio.pause() : audio.play()
   }
 
   const updateDuration = e => {
@@ -79,7 +79,7 @@ const Episode = ({
       <div className="episode-info">
         <button
           className="audio-control"
-          onClick={() => togglePlay()}
+          onClick={togglePlay}
           aria-label={isPlaying ? "Pause podcast" : "Play podcast"}
         >
           {isPlaying ? (


### PR DESCRIPTION
Because the default isPlaying is set to false I think line 25 just needed to be swapped. It fixes the issue but honestly the logic still doesn't make sense to me.