### PR TITLE
fix(social-sharing): logo not appearing

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,10 +1,15 @@
 const path = require(`path`)
 
+const URL = "https://www.ladybug.dev"
+
+const publicUrl = process.env.NODE_ENV === "production" ? URL : ""
+
 module.exports = {
   siteMetadata: {
     title: `Ladybug Podcast`,
     description: `Emma Bostian, Kelly Vaughn, and Ali Spittel talk career and code.`,
     author: `@emmabostian`,
+    publicUrl,
   },
   plugins: [
     `gatsby-plugin-react-helmet`,

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -70,7 +70,7 @@ function SEO({ description, lang, meta, title, episodeInfo }) {
         },
         {
           name: `twitter:card`,
-          content: `summary`,
+          content: `summary_large_image`,
         },
         {
           name: `twitter:creator`,

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -10,7 +10,7 @@ import PropTypes from "prop-types"
 import Helmet from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
-import metaImage from '../images/meta/website-image.png'
+import metaImage from "../images/meta/website-image.png"
 
 function SEO({ description, lang, meta, title, episodeInfo }) {
   const { site } = useStaticQuery(
@@ -21,15 +21,16 @@ function SEO({ description, lang, meta, title, episodeInfo }) {
             title
             description
             author
+            publicUrl
           }
         }
       }
     `
   )
-
-  const siteURL = `https://www.ladybug.dev/`
+  const { publicUrl, author } = site.siteMetadata
   const metaTitle = title || episodeInfo.title
-  const metaDescription = (episodeInfo && episodeInfo.description) || site.siteMetadata.description
+  const metaDescription =
+    (episodeInfo && episodeInfo.description) || site.siteMetadata.description
 
   return (
     <Helmet
@@ -45,7 +46,7 @@ function SEO({ description, lang, meta, title, episodeInfo }) {
         },
         {
           property: `og:url`,
-          content: siteURL,
+          content: publicUrl,
         },
         {
           property: `og:title`,
@@ -61,19 +62,19 @@ function SEO({ description, lang, meta, title, episodeInfo }) {
         },
         {
           property: `og:image`,
-          content: metaImage,
+          content: publicUrl + metaImage,
         },
         {
           property: `twitter:url`,
-          content: siteURL,
+          content: publicUrl,
         },
         {
           name: `twitter:card`,
-          content: `summary_large_image`,
+          content: `summary`,
         },
         {
           name: `twitter:creator`,
-          content: site.siteMetadata.author,
+          content: author,
         },
         {
           name: `twitter:title`,
@@ -84,8 +85,8 @@ function SEO({ description, lang, meta, title, episodeInfo }) {
           content: metaDescription,
         },
         {
-          property: `twitter:image`,
-          content: metaImage
+          name: `twitter:image`,
+          content: publicUrl + metaImage,
         },
       ].concat(meta)}
     />


### PR DESCRIPTION
**Issues**

There were few issues with the implementation of meta tags for sharing (not 100% sure as these things are always tricky 🤣 ):
1. The key for `twitter:image` should be `name` instead of <del>`property`</del> (maybe)
```diff
- property: "twitter:image"
+ name: "twitter:image"
```
2. We should always provide the absolute url when adding images/assets for social sharing (sure)
```diff
- content: imageUrl
+ content: publicUrl + imageUrl
```

**Updates**

1. I have updated the `gatsby-config.js` file to include the `publicUrl` which can be used to prefix any url is required by accessing the site's meta data with graphql