### PR TITLE
SEO declaration using incorrect title variable

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -37,7 +37,7 @@ function SEO({ description, lang, meta, title, episodeInfo }) {
       htmlAttributes={{
         lang,
       }}
-      title={title}
+      title={metaTitle}
       titleTemplate={`%s | ${site.siteMetadata.title}`}
       meta={[
         {


### PR DESCRIPTION
It worked for the pages apart form the episode ones which used a different prop name