### PR TITLE
Removes warning and fixes issues #25 and #65

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -103,7 +103,7 @@ SEO.propTypes = {
   description: PropTypes.string,
   lang: PropTypes.string,
   meta: PropTypes.arrayOf(PropTypes.object),
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
 }
 
 export default SEO

--- a/src/templates/episode.js
+++ b/src/templates/episode.js
@@ -41,7 +41,7 @@ export default function Template({ data }) {
         <Link to="/episodes">
           <button className="button button-border">Back to episodes</button>
         </Link>
-        <p
+        <div
           dangerouslySetInnerHTML={{
             __html: html,
           }}


### PR DESCRIPTION
This PR includes:

* Removes a warning from devtools
```
index.js:2177 Warning: Failed prop type: The prop `title` is marked as required in `SEO`, but its value is `undefined`.
    in SEO (at episode.js:28)
    in Template (created by HotExportedTemplate)
```

* Fixes the issue reported in #25 and #65 
From what I quickly googled, it was reported here https://github.com/gatsbyjs/gatsby/issues/11108 and they subsequently point to https://github.com/facebook/react/issues/5479.
