### PR TITLE
Fix transscript link in episode 34

### DIFF
--- a/src/episodes/2020-03-16-whats-on-our-computers/index.md
+++ b/src/episodes/2020-03-16-whats-on-our-computers/index.md
@@ -130,4 +130,4 @@ To learn more, visit <a href="http://aws-amplify.github.io/">aws-amplify.github.
 
 # Transcript
 
-We provide transcripts for all of our episodes. You can find them <a href="https://github.com/ladybug-podcast/ladybug-website/blob/master/transcripts/33-behavioral-interviews.md" target="_blank" class="highlight">here!</a>
+We provide transcripts for all of our episodes. You can find them <a href="https://github.com/ladybug-podcast/ladybug-website/blob/master/transcripts/34-whats-on-our-computers.md" target="_blank" class="highlight">here!</a>


### PR DESCRIPTION
The transscript link in [episode 34 - What's on our computers](https://www.ladybug.dev/episodes/whats-on-our-computers) is pointing to the wrong transscript file.